### PR TITLE
Add JW Library playlist import support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ out/
 
 # tests
 /test/tmp
+*.jwlplaylist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-01-23
+
+### Added
+- Import JW Library playlists (.jwlplaylist files) via drag/drop or Add Files menu
+- Optional title field for media files, displayed instead of filename when set
+- Imported playlist items preserve their original order and titles
+
 ## [2.5.0] - 2026-01-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,30 +8,35 @@ JWPlay is an Electron-based media presenter application designed for 2-screen se
 
 ## Commands
 
+This project uses **yarn** (not npm). Do not use `package-lock.json`.
+
 ```bash
+# Install dependencies
+yarn install
+
 # Development (with hot reload via nodemon)
-npm run dev
+yarn dev
 
 # Run tests
-npm test
+yarn test
 
 # Run a single test file
-npx jest test/MediaFile.test.js
+yarn jest test/MediaFile.test.js
 
 # Lint and format code
-npm run lint
+yarn lint
 
 # Package for development testing
-npm run package
+yarn package
 
 # Build for distribution
-npm run make
-npm run pack-win     # Windows
-npm run pack-linux   # Linux
-npm run pack-mac     # macOS
+yarn make
+yarn pack-win     # Windows
+yarn pack-linux   # Linux
+yarn pack-mac     # macOS
 
 # Clear app config (useful for testing)
-npm run clear-config
+yarn clear-config
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ A media presenter application designed for 2-screen setups, perfect for remote m
 
 ## Screenshots
 
-<!-- TODO: Add updated screenshots -->
-<img width="1409" alt="JW Play Screenshot" src="https://user-images.githubusercontent.com/226834/164533878-ba148626-8fa9-4ab9-879a-522c0d2d291e.png">
+<img width="800" alt="JW Play - Image display with zoom controls" src="https://github.com/user-attachments/assets/a448b03f-4542-4565-bf10-d35d6836d143">
+
+<img width="800" alt="JW Play - Video playback controls" src="https://github.com/user-attachments/assets/b38dbc0d-6849-4a3f-b621-341827976273">
+
+<img width="800" alt="JW Play - PDF viewer with page navigation" src="https://github.com/user-attachments/assets/2271ed2f-e896-4bbf-8602-5324dde5b308">
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,70 @@
-A prototype player meant for remote meetings. Made with [Electron JS](https://www.electronjs.org/).
+# JW Play
 
-## Development
+A media presenter application designed for 2-screen setups, perfect for remote meetings. Built with [Electron](https://www.electronjs.org/).
 
-Install ffmpeg if you you want to see vídeo thumbnails
+## Features
 
-```
-npm install
-npm dev
-```
+### Media Support
+- **Images** - PNG, JPEG, JPG, GIF with zoom and pan controls
+- **Videos** - MP4, MPEG, M4V, MOV with playback controls
+- **PDFs** - Page navigation with slider, zoom and pan support
+- **JW Library Playlists** - Import .jwlplaylist files with preserved order and titles
 
-## Compile
+### Two-Window System
+- **Control Window** - Manage your media library with thumbnails
+- **Display Window** - Full-screen capable output for your audience
 
-```
-npm run package # check the out file
-```
+### Controls
+- Unified control bar for all media types
+- Zoom in/out/fit controls for images and PDFs
+- Pan controls (arrow buttons, keyboard, or click-and-drag)
+- Video playback controls with progress bar
+- PDF page navigation with slider
 
-## Running tests
-
-```
-npm test
-```
-
-## Linting
-
-```
-./node_modules/.bin/prettier --write src test
-```
+### Productivity
+- Drag and drop files to add them
+- Drag and drop to reorder media
+- Keyboard shortcuts for pan (hjkl, arrow keys) and zoom (u/i)
+- Mouse wheel zoom in display window
+- Multi-language support (English, Portuguese)
 
 ## Screenshots
 
-<img width="1409" alt="image" src="https://user-images.githubusercontent.com/226834/164533878-ba148626-8fa9-4ab9-879a-522c0d2d291e.png">
-<img width="1404" alt="image" src="https://user-images.githubusercontent.com/226834/164558200-d6eb90ad-ec09-493d-b0ca-db03186eb61c.png">
+<!-- TODO: Add updated screenshots -->
+<img width="1409" alt="JW Play Screenshot" src="https://user-images.githubusercontent.com/226834/164533878-ba148626-8fa9-4ab9-879a-522c0d2d291e.png">
 
 ## Installation
 
-- Find the installation files in the latest [release](https://github.com/mjacobus/jw-play/releases/latest)
+Download the latest release for your platform from the [releases page](https://github.com/mjacobus/jw-play/releases/latest).
+
+## Development
+
+This project uses **yarn** (not npm).
+
+```bash
+# Install dependencies
+yarn install
+
+# Run in development mode (with hot reload)
+yarn dev
+
+# Run tests
+yarn test
+
+# Lint and format code
+yarn lint
+
+# Package for testing
+yarn package
+
+# Build for distribution
+yarn pack-mac     # macOS
+yarn pack-win     # Windows
+yarn pack-linux   # Linux
+```
+
+Note: Install ffmpeg if you want video thumbnails to be generated.
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     }
   },
   "dependencies": {
+    "adm-zip": "^0.5.16",
     "bootstrap": "^4.6.0",
     "bootstrap-icons": "^1.4.0",
     "delegated-events": "^1.1.2",
@@ -105,6 +106,7 @@
     "image-size": "^1.0.2",
     "lodash": "^4.17.21",
     "pdfjs-dist": "^3.11.174",
+    "sql.js": "^1.13.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "JWPlay",
   "productName": "JWPlay2",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "This is a media presenter for 2-screen computers.",
   "main": "src/app.js",
   "build": {

--- a/src/ControlWindow.js
+++ b/src/ControlWindow.js
@@ -55,7 +55,9 @@ class ControlWindow extends Window {
   addFile(filePath) {
     // Handle .jwlplaylist files
     if (filePath.endsWith(".jwlplaylist")) {
-      this.#importPlaylist(filePath);
+      this.#importPlaylist(filePath).catch((error) => {
+        console.error("Failed to import playlist:", error);
+      });
       return;
     }
 

--- a/src/ControlWindow.js
+++ b/src/ControlWindow.js
@@ -2,6 +2,7 @@ const { ipcMain } = require("electron");
 const fs = require("fs");
 const path = require("path");
 const MediaFiles = require("./MediaFiles");
+const PlaylistImporter = require("./PlaylistImporter");
 
 const Window = require("./Window");
 
@@ -52,6 +53,12 @@ class ControlWindow extends Window {
   }
 
   addFile(filePath) {
+    // Handle .jwlplaylist files
+    if (filePath.endsWith(".jwlplaylist")) {
+      this.#importPlaylist(filePath);
+      return;
+    }
+
     const file = this.medias.createFromPath(filePath);
 
     if (!file.exists() || !file.isSupported()) {
@@ -59,6 +66,20 @@ class ControlWindow extends Window {
     }
 
     this.webContents.send("add-file", file.getId());
+  }
+
+  async #importPlaylist(filePath) {
+    const filesDir = path.join(this.app.getPath("appData"), "JWPlay", "files");
+    const importer = new PlaylistImporter(filePath, filesDir);
+
+    try {
+      const importedFiles = await importer.import(this.medias);
+      importedFiles.forEach((file) => {
+        this.webContents.send("add-file", file.getId());
+      });
+    } catch (error) {
+      console.error("Failed to import playlist:", error);
+    }
   }
 
   addFolder(folder) {

--- a/src/MediaFile.js
+++ b/src/MediaFile.js
@@ -63,6 +63,14 @@ class MediaFile {
     return path.basename(this.getPath());
   }
 
+  getTitle() {
+    return this.#data.title || this.getFilename();
+  }
+
+  setTitle(title) {
+    this.#data.title = title;
+  }
+
   getThumbnailUrl() {
     return `file://${this.getThumbnailPath()}`;
   }

--- a/src/MediaFiles.js
+++ b/src/MediaFiles.js
@@ -88,12 +88,17 @@ class MediaFiles {
     this.setOrder([]);
   }
 
-  createFromPath(path) {
+  createFromPath(path, options = {}) {
     if (!this.#filesPath) {
       throw new Error("Files path not set");
     }
 
     const data = { id: uuid(), path };
+
+    if (options.title) {
+      data.title = options.title;
+    }
+
     const file = new MediaFile(data);
 
     data.thumbnailPath = file.getPath();

--- a/src/PlaylistImporter.js
+++ b/src/PlaylistImporter.js
@@ -102,8 +102,8 @@ class PlaylistImporter {
     // Copy the file to the permanent location
     fs.copyFileSync(sourceFile, destPath);
 
-    // Create the media file entry
-    return mediaFiles.createFromPath(destPath);
+    // Create the media file entry with the playlist item's label as title
+    return mediaFiles.createFromPath(destPath, { title: item.Label });
   }
 
   #getExtFromMime(mimeType) {

--- a/src/PlaylistImporter.js
+++ b/src/PlaylistImporter.js
@@ -1,0 +1,134 @@
+const AdmZip = require("adm-zip");
+const initSqlJs = require("sql.js");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+
+class PlaylistImporter {
+  #zipPath = null;
+  #tempDir = null;
+  #filesDir = null;
+  #db = null;
+
+  constructor(zipPath, filesDir) {
+    this.#zipPath = zipPath;
+    this.#filesDir = filesDir;
+  }
+
+  async import(mediaFiles) {
+    try {
+      this.#extract();
+      await this.#openDatabase();
+      const items = this.#getPlaylistItems();
+
+      const importedFiles = [];
+      for (const item of items) {
+        const file = this.#importItem(item, mediaFiles);
+        if (file) {
+          importedFiles.push(file);
+        }
+      }
+
+      return importedFiles;
+    } finally {
+      this.#cleanup();
+    }
+  }
+
+  #extract() {
+    this.#tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "jwplaylist-"));
+    const zip = new AdmZip(this.#zipPath);
+    zip.extractAllTo(this.#tempDir, true);
+  }
+
+  async #openDatabase() {
+    const SQL = await initSqlJs();
+    const dbPath = path.join(this.#tempDir, "userData.db");
+    const buffer = fs.readFileSync(dbPath);
+    this.#db = new SQL.Database(buffer);
+  }
+
+  #getPlaylistItems() {
+    // Query playlist items in order, joining with IndependentMedia to get the actual media files
+    const query = `
+      SELECT
+        pi.PlaylistItemId,
+        pi.Label,
+        im.OriginalFilename,
+        im.FilePath,
+        im.MimeType
+      FROM PlaylistItem pi
+      JOIN PlaylistItemIndependentMediaMap pim ON pi.PlaylistItemId = pim.PlaylistItemId
+      JOIN IndependentMedia im ON pim.IndependentMediaId = im.IndependentMediaId
+      ORDER BY pi.PlaylistItemId
+    `;
+
+    const results = this.#db.exec(query);
+    if (!results.length) {
+      return [];
+    }
+
+    const columns = results[0].columns;
+    return results[0].values.map((row) => {
+      const item = {};
+      columns.forEach((col, index) => {
+        item[col] = row[index];
+      });
+      return item;
+    });
+  }
+
+  #importItem(item, mediaFiles) {
+    const sourceFile = path.join(this.#tempDir, item.FilePath);
+
+    if (!fs.existsSync(sourceFile)) {
+      console.warn(`Source file not found: ${sourceFile}`);
+      return null;
+    }
+
+    // Use the Label as the filename (it contains the original name)
+    const label = item.Label;
+    const ext = path.extname(label) || this.#getExtFromMime(item.MimeType);
+    const baseName = path.basename(label, ext);
+
+    // Create a unique filename to avoid conflicts
+    const uniqueFilename = `${baseName}_${Date.now()}${ext}`;
+    const importedDir = path.join(this.#filesDir, "imported");
+    const destPath = path.join(importedDir, uniqueFilename);
+
+    // Ensure the imported directory exists
+    fs.mkdirSync(importedDir, { recursive: true });
+
+    // Copy the file to the permanent location
+    fs.copyFileSync(sourceFile, destPath);
+
+    // Create the media file entry
+    return mediaFiles.createFromPath(destPath);
+  }
+
+  #getExtFromMime(mimeType) {
+    const mimeToExt = {
+      "video/mp4": ".mp4",
+      "video/mpeg": ".mpeg",
+      "video/quicktime": ".mov",
+      "image/jpeg": ".jpg",
+      "image/png": ".png",
+      "image/gif": ".gif",
+    };
+    return mimeToExt[mimeType] || "";
+  }
+
+  #cleanup() {
+    if (this.#db) {
+      this.#db.close();
+      this.#db = null;
+    }
+    // Clean up the temp directory since files have been copied to the permanent location
+    if (this.#tempDir && fs.existsSync(this.#tempDir)) {
+      fs.rmSync(this.#tempDir, { recursive: true, force: true });
+      this.#tempDir = null;
+    }
+  }
+}
+
+module.exports = PlaylistImporter;

--- a/src/PlaylistImporter.js
+++ b/src/PlaylistImporter.js
@@ -3,6 +3,7 @@ const initSqlJs = require("sql.js");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
+const { uuid } = require("./utils");
 
 class PlaylistImporter {
   #zipPath = null;
@@ -38,7 +39,24 @@ class PlaylistImporter {
   #extract() {
     this.#tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "jwplaylist-"));
     const zip = new AdmZip(this.#zipPath);
-    zip.extractAllTo(this.#tempDir, true);
+
+    // Safe extraction: validate each entry to prevent path traversal
+    for (const entry of zip.getEntries()) {
+      const entryName = path.normalize(entry.entryName).replace(/^([/\\])+/, "");
+      const destPath = path.join(this.#tempDir, entryName);
+
+      // Skip entries that would escape the temp directory
+      if (!destPath.startsWith(this.#tempDir + path.sep)) {
+        continue;
+      }
+
+      if (entry.isDirectory) {
+        fs.mkdirSync(destPath, { recursive: true });
+      } else {
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        fs.writeFileSync(destPath, entry.getData());
+      }
+    }
   }
 
   async #openDatabase() {
@@ -79,20 +97,25 @@ class PlaylistImporter {
   }
 
   #importItem(item, mediaFiles) {
-    const sourceFile = path.join(this.#tempDir, item.FilePath);
+    // Prevent path traversal: resolve and validate the source path
+    const sourceFile = path.resolve(this.#tempDir, item.FilePath);
+    if (!sourceFile.startsWith(this.#tempDir + path.sep)) {
+      console.warn(`Rejected playlist item due to invalid path: ${item.FilePath}`);
+      return null;
+    }
 
     if (!fs.existsSync(sourceFile)) {
       console.warn(`Source file not found: ${sourceFile}`);
       return null;
     }
 
-    // Use the Label as the filename (it contains the original name)
+    // Sanitize label for use in filename (remove unsafe characters)
     const label = item.Label;
     const ext = path.extname(label) || this.#getExtFromMime(item.MimeType);
-    const baseName = path.basename(label, ext);
+    const baseName = this.#sanitizeFilename(path.basename(label, ext));
 
-    // Create a unique filename to avoid conflicts
-    const uniqueFilename = `${baseName}_${Date.now()}${ext}`;
+    // Create a unique filename using uuid to avoid collisions
+    const uniqueFilename = `${baseName}_${uuid()}${ext}`;
     const importedDir = path.join(this.#filesDir, "imported");
     const destPath = path.join(importedDir, uniqueFilename);
 
@@ -104,6 +127,11 @@ class PlaylistImporter {
 
     // Create the media file entry with the playlist item's label as title
     return mediaFiles.createFromPath(destPath, { title: item.Label });
+  }
+
+  #sanitizeFilename(name) {
+    // Remove characters that are unsafe for filenames across platforms
+    return name.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_");
   }
 
   #getExtFromMime(mimeType) {

--- a/src/pages/controls.js
+++ b/src/pages/controls.js
@@ -178,8 +178,8 @@ const loadFileHandler = (file, li) => (e) => {
     applyTranslations(footer);
     const fileNameEl = document.getElementById(fileNameElementId);
     if (fileNameEl) {
-      fileNameEl.textContent = file.getFilename();
-      fileNameEl.title = file.getFilename();
+      fileNameEl.textContent = file.getTitle();
+      fileNameEl.title = file.getTitle();
     }
   } else {
     footer.innerHTML = "";
@@ -205,8 +205,8 @@ ipcRenderer.on("add-file", (_, fileId) => {
 
   const img = document.createElement("img");
   img.src = file.getThumbnailUrl();
-  img.title = file.getFilename();
-  img.alt = file.getFilename();
+  img.title = file.getTitle();
+  img.alt = file.getTitle();
   a.appendChild(img);
 
   if (file.isPdf()) {
@@ -222,7 +222,7 @@ ipcRenderer.on("add-file", (_, fileId) => {
   removeButton.onclick = (e) => {
     e.preventDefault();
     if (
-      confirm(t("messages.confirmFileRemoval", { file: file.getFilename() }))
+      confirm(t("messages.confirmFileRemoval", { file: file.getTitle() }))
     ) {
       filesContainer.removeChild(li);
       ipcRenderer.send("file:remove", file.getId());

--- a/src/pages/controls.js
+++ b/src/pages/controls.js
@@ -179,7 +179,7 @@ const loadFileHandler = (file, li) => (e) => {
     const fileNameEl = document.getElementById(fileNameElementId);
     if (fileNameEl) {
       fileNameEl.textContent = file.getTitle();
-      fileNameEl.title = file.getTitle();
+      fileNameEl.title = file.getFilename();
     }
   } else {
     footer.innerHTML = "";
@@ -205,7 +205,7 @@ ipcRenderer.on("add-file", (_, fileId) => {
 
   const img = document.createElement("img");
   img.src = file.getThumbnailUrl();
-  img.title = file.getTitle();
+  img.title = file.getFilename();
   img.alt = file.getTitle();
   a.appendChild(img);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,7 +853,7 @@
 
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
+  resolved "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz"
   integrity sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==
   dependencies:
     detect-libc "^2.0.0"
@@ -1175,6 +1175,11 @@ acorn@^8.2.4:
   version "8.7.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+adm-zip@^0.5.16:
+  version "0.5.16"
+  resolved "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz"
+  integrity sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -1847,7 +1852,7 @@ caniuse-lite@^1.0.30001317:
 
 canvas@^2.11.2:
   version "2.11.2"
-  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.11.2.tgz#553d87b1e0228c7ac0fc72887c3adbac4abbd860"
+  resolved "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz"
   integrity sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.0"
@@ -5095,7 +5100,7 @@ mute-stream@0.0.8:
 
 nan@^2.17.0:
   version "2.24.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.24.0.tgz#a8919b36e692aa5b260831910e4f81419fc0a283"
+  resolved "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz"
   integrity sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==
 
 nanomatch@^1.2.9:
@@ -6325,7 +6330,7 @@ simple-concat@^1.0.0:
 
 simple-get@^3.0.3:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
+  resolved "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz"
   integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
   dependencies:
     decompress-response "^4.2.0"
@@ -6503,6 +6508,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sql.js@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz"
+  integrity sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==
 
 sshpk@^1.7.0:
   version "1.17.0"


### PR DESCRIPTION
## Summary
- Add support for importing .jwlplaylist files from JW Library app
- Playlist items are imported preserving their original order
- Works via drag/drop or Add Files menu (no separate menu item needed)

## Implementation
- New `PlaylistImporter` class handles zip extraction and SQLite parsing
- Integrated into existing `ControlWindow.addFile()` flow
- Media files are copied to app's permanent storage directory

## Test plan
- [ ] Drag and drop a .jwlplaylist file onto the control window
- [ ] Use Add Files menu to select a .jwlplaylist file
- [ ] Verify items appear in the correct order
- [ ] Verify both images and videos from the playlist work

🤖 Generated with [Claude Code](https://claude.com/claude-code)